### PR TITLE
use promhttp as prometheus.Handler is deprecated

### DIFF
--- a/cmd/bash-exporter/bash-exporter.go
+++ b/cmd/bash-exporter/bash-exporter.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gree-gorey/bash-exporter/pkg/run"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -55,7 +56,7 @@ func main() {
 		}
 	}
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	go Run(int(*interval), *path, names, labelsArr, *debug)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }


### PR DESCRIPTION
go build is failing with: 

./bash-exporter.go:58:26: undefined: prometheus.Handler

prometheus.Handler seems to be deprecated. replaced with promhttp.Handler