### PR TITLE
fix docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.10.1
+FROM golang:1.11.1
 RUN go get -d -v github.com/gree-gorey/bash-exporter/cmd/bash-exporter
 WORKDIR /go/src/github.com/gree-gorey/bash-exporter/cmd/bash-exporter
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bash-exporter .
 
-FROM alpine:3.7
+FROM alpine:3.10
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/gree-gorey/bash-exporter/cmd/bash-exporter/bash-exporter .
 COPY ./examples/* /scripts/


### PR DESCRIPTION
Update golang image version to 1.11.1. `go get` compatibilty issue which was causing `docker build` to fail was fixed in https://github.com/golang/go/commit/fce993d1a27153271919db00d2f80b6839fcb326.
Update Alpine image version to 3.10. 